### PR TITLE
Services store with channel communication

### DIFF
--- a/lib/whos_able/util.ex
+++ b/lib/whos_able/util.ex
@@ -1,0 +1,13 @@
+defmodule WhosAble.Util do
+  def shared_assign(%Plug.Conn{} = conn, key, value), do: Plug.Conn.assign(conn, key, value)
+  def shared_assign(%Phoenix.Socket{} = conn, key, value), do: Phoenix.Socket.assign(conn, key, value)
+
+  def scrub_params(params) do
+    for {k, v} <- params, into: %{} do
+      case v == "" do
+        true -> {k, nil}
+        false -> {k, v}
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20160430164119_services.exs
+++ b/priv/repo/migrations/20160430164119_services.exs
@@ -1,0 +1,15 @@
+defmodule WhosAble.Repo.Migrations.Services do
+  use Ecto.Migration
+
+  def change do
+    create table(:services) do
+      add :name, :string
+      add :account_id, references(:accounts)
+
+      timestamps
+    end
+
+    create index(:services, [:account_id])
+    create unique_index(:services, [:name])
+  end
+end

--- a/web/channels/account_channel/service.ex
+++ b/web/channels/account_channel/service.ex
@@ -1,0 +1,36 @@
+defmodule WhosAble.AccountChannel.Service do
+  use WhosAble.Web, :channel
+
+  import Ecto.Query
+
+  def all_services(socket) do
+    account = WhosAble.AccountChannel.get_account(socket)
+
+    broadcast(socket, "all_services", services_json(account))
+  end
+
+  def new_service(service, socket) do
+    broadcast(socket, "new_service", service_json(service))
+  end
+
+  ###
+  ### PRIVATE
+  ###
+
+  defp service_json(service) do
+    %{
+      id: service.id,
+      name: service.name
+    }
+  end
+
+  defp services_json(account) do
+    services = WhosAble.Service
+    |> where(account_id: ^account.id)
+    |> Repo.all
+    |> Enum.reduce([], fn(service, acc) -> List.insert_at(acc, 0, %{id: service.id, name: service.name}) end)
+    %{
+      services: services
+    }
+  end
+end

--- a/web/models/service.ex
+++ b/web/models/service.ex
@@ -1,0 +1,21 @@
+defmodule WhosAble.Service do
+  use WhosAble.Web, :model
+
+  schema "services" do
+    field :name
+
+    belongs_to :account, WhosAble.Account
+
+    timestamps
+  end
+
+  ###
+  ### CHANGESETS
+  ###
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(account_id name), [])
+    |> unique_constraint(:name)
+  end
+end

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -6,6 +6,7 @@ import {Router, Route, browserHistory} from 'react-router';
 window.Dispatcher = require("./dispatcher");
 
 window.AuthStore = require("./stores/auth-store");
+window.ServiceStore = require("./stores/service-store");
 window.AuthStore.connectSocket();
 
 var HomePage = require("./react/pages/home-page");

--- a/web/static/js/dispatcher.js
+++ b/web/static/js/dispatcher.js
@@ -1,6 +1,13 @@
 import { browserHistory } from 'react-router';
 
 var Dispatcher = {
+  createService(name) {
+    return window.AuthStore.channel.push("create_service", {name: name})
+    /*  .receive("ok", (resp) => {
+      }).receive("error", (resp) => {
+      });*/
+  },
+
   login(email, password) {
     return $.ajax({
       method: "POST",

--- a/web/static/js/react/forms/signup-form.js
+++ b/web/static/js/react/forms/signup-form.js
@@ -61,7 +61,7 @@ var SignupForm = React.createClass({
         </button>
       );
     } else {
-      return(<button type="submit" className="btn btn-primary" onClick={ this.signup }>Submit</button>);
+      return(<button type="submit" className="btn btn-primary" onClick={ this.signup }>Signup</button>);
     }
   },
 

--- a/web/static/js/react/pages/dashboard-page.js
+++ b/web/static/js/react/pages/dashboard-page.js
@@ -3,8 +3,26 @@ var NavBar = require("../nav-bar");
 import {browserHistory} from 'react-router';
 
 var DashboardPage = React.createClass({
+  getInitialState() {
+    return {
+      services: null
+    };
+  },
+
   handleCreate() {
     browserHistory.push("/app/jobs/new")
+  },
+
+  componentDidMount() {
+    window.ServiceStore.subscribe(this.receiveState);
+  },
+
+  componentWillUnmount() {
+    window.ServiceStore.unsubscribe(this.receiveState);
+  },
+
+  receiveState(services) {
+    this.setState({services: services});
   },
 
   render() {

--- a/web/static/js/stores/auth-store.js
+++ b/web/static/js/stores/auth-store.js
@@ -63,8 +63,8 @@ module.exports = {
 
       window.AuthStore.channel = window.AuthStore.socket.channel("account:" + window.AuthStore.accountID, {token: window.AuthStore.token})
       window.AuthStore.channel.join()
-        .receive("ok", resp => { console.log("Joined successfully", resp) })
-        .receive("error", resp => { console.log("Unable to join", resp) })
+        .receive("ok", (resp) => { console.log("Joined successfully", resp); })
+        .receive("error", (resp) => { console.log("Unable to join", resp); });
     }
   },
 };

--- a/web/static/js/stores/service-store.js
+++ b/web/static/js/stores/service-store.js
@@ -1,0 +1,57 @@
+import {Socket} from "phoenix"
+
+module.exports = {
+  services: {},
+  callBacks: [],
+
+  subscribe(callBack) {
+    window.ServiceStore.connectToChannel();
+    window.ServiceStore.callBacks.push(callBack);
+    window.ServiceStore.sendCallBack(callBack);
+  },
+
+  unsubscribe(callBack) {
+    var i = window.ServiceStore.callBacks.indexOf(callBack);
+    if(i != -1) {
+      window.ServiceStore.callBacks.splice(i, 1);
+    }
+  },
+
+  sendCallBacks() {
+    window.ServiceStore.callBacks.forEach(function (callBack) {
+      if(callBack && typeof(callBack) === "function") {
+        window.ServiceStore.sendCallBack(callBack);
+      }
+    });
+  },
+
+  sendCallBack(callBack) {
+    callBack(window.ServiceStore.services);
+  },
+
+  addNewService(service) {
+    window.ServiceStore.services[service.id] = service;
+    window.ServiceStore.sendCallBacks();
+  },
+
+  refreshServices(services) {
+    var newServices = {};
+    services.forEach(function (service) {
+      newServices[service.id] = service;
+    });
+    window.ServiceStore.services = newServices;
+    window.ServiceStore.sendCallBacks();
+  },
+
+  connectToChannel() {
+    if(window.AuthStore.isLoggedIn() && window.AuthStore.channel && Object.keys(window.ServiceStore.services).length === 0) {
+      window.AuthStore.channel.on("new_service", (service) => {
+        window.ServiceStore.addNewService(service);
+      })
+      window.AuthStore.channel.on("all_services", (response) => {
+        window.ServiceStore.refreshServices(response.services);
+      });
+      window.AuthStore.channel.push("request_services", {});
+    }
+  }
+};

--- a/web/web.ex
+++ b/web/web.ex
@@ -69,6 +69,7 @@ defmodule WhosAble.Web do
       import Ecto
       import Ecto.Query, only: [from: 1, from: 2]
       import WhosAble.Gettext
+      import WhosAble.Util, only: [scrub_params: 1]
     end
   end
 


### PR DESCRIPTION
New store called ServiceStore. It stores the service types for an account.
Any component can subscribe the ServiceStore. If you subscribe, it will send callback anytime it has an update. A new subscriber will call the server to get all services if the store does not actually have them yet.

This pull request also introduces a new Dispatcher function createService. It takes a name as the only parameter. The function returns a push object that can be bound to. So the form component can bind .receive("ok" or .receive("error". ok returns service_id and error returns the changeset errors.
